### PR TITLE
Input value handling during validation fix

### DIFF
--- a/packages/core/src/forms.spec.ts
+++ b/packages/core/src/forms.spec.ts
@@ -1,6 +1,6 @@
 import { toFormState, toResult, validateForm, mkInputState, validate } from "./forms"
 import { mkOk } from "@react-formless/utils/validators"
-import { FormSchema, FormState, Tuples } from "../src"
+import { FormSchema, FormState, Tuples, SimpleInputProps } from "../src"
 
 type Tag2 = { name: string }
 type Skill = { name: string; level: number }
@@ -378,43 +378,32 @@ describe("inputstate", () => {
         })
     })
 
-    describe("getFormProps", () => {
-        describe("validate", () => {
-            const value = { val: 1 }
-            const input = {
-                state: { stateValue: "val", anotherStateValue: "val2" },
-                schema: {
-                    toValue: undefined,
-                    type: "",
-                    validators: undefined
-                },
-                setDelta: jest.fn()
-            }
-            beforeEach(() => {
-                input.setDelta.mockReset()
-            })
-            it("sets state, value and validation result with setDelta", () => {
-                validate(input, value)
-                expect(input.setDelta).toBeCalledWith({ ...input.state, validationResult: mkOk(value), value })
-            })
-            it("returns validation result", () => {
-                expect(validate(input, value)).toEqual(mkOk(value))
-            })
-            describe("when toValue is set", () => {
-                const toValueReturn = { transformed: "1" }
-                const inputWithToValue = {
-                    ...input,
-                    schema: {
-                        ...input.schema,
-                        toValue: jest.fn().mockReturnValue(toValueReturn)
-                    }
-                }
-                it("should should transform value with given function", () => {
-                    validate(inputWithToValue, value)
-                    expect(inputWithToValue.schema.toValue).toBeCalledWith(value)
-                    expect(inputWithToValue.setDelta.mock.calls[0][0].value).toEqual(toValueReturn)
-                })
-            })
+    describe("validate()", () => {
+        type N = { foo: number }
+        const state: N = { foo: 1 }
+        const input: SimpleInputProps = { state, schema: { type: "number" }, setDelta: jest.fn() }
+        const value = { foo: 2 }
+
+        beforeEach(() => input.setDelta.mockReset())
+
+        it("sets state, value and validation result with setDelta", () => {
+            validate<N>(input, value)
+            const expected = { ...input.state, value, validationResult: mkOk(value) }
+            expect(input.setDelta).toBeCalledWith(expected)
+        })
+
+        it("returns validation result", () => {
+            const current = validate<N>(input, value)
+            expect(current).toEqual(mkOk(value))
+        })
+
+        it("should should transform value with given function", () => {
+            const result = { foo: "1" }
+            const toValue = jest.fn().mockReturnValue(result)
+            validate<N>({ ...input, schema: { ...input.schema, toValue } }, value)
+
+            expect(toValue).toBeCalledWith(value)
+            expect(input.setDelta.mock.calls[0][0].value).toEqual(result)
         })
     })
     // tslint:disable-next-line:max-file-line-count

--- a/packages/core/src/forms.spec.ts
+++ b/packages/core/src/forms.spec.ts
@@ -1,4 +1,4 @@
-import { toFormState, toResult, validateForm, mkInputState } from "./forms"
+import { toFormState, toResult, validateForm, mkInputState, validate } from "./forms"
 import { mkOk } from "@react-formless/utils/validators"
 import { FormSchema, FormState, Tuples } from "../src"
 
@@ -375,6 +375,46 @@ describe("inputstate", () => {
                 ]
             }
             expect(validateForm(userSchema, state)).toEqual(expectedState)
+        })
+    })
+
+    describe("getFormProps", () => {
+        describe("validate", () => {
+            const value = { val: 1 }
+            const input = {
+                state: { stateValue: "val", anotherStateValue: "val2" },
+                schema: {
+                    toValue: undefined,
+                    type: "",
+                    validators: undefined
+                },
+                setDelta: jest.fn()
+            }
+            beforeEach(() => {
+                input.setDelta.mockReset()
+            })
+            it("sets state, value and validation result with setDelta", () => {
+                validate(input, value)
+                expect(input.setDelta).toBeCalledWith({ ...input.state, validationResult: mkOk(value), value })
+            })
+            it("returns validation result", () => {
+                expect(validate(input, value)).toEqual(mkOk(value))
+            })
+            describe("when toValue is set", () => {
+                const toValueReturn = { transformed: "1" }
+                const inputWithToValue = {
+                    ...input,
+                    schema: {
+                        ...input.schema,
+                        toValue: jest.fn().mockReturnValue(toValueReturn)
+                    }
+                }
+                it("should should transforn valu with given function", () => {
+                    validate(inputWithToValue, value)
+                    expect(inputWithToValue.schema.toValue).toBeCalledWith(value)
+                    expect(inputWithToValue.setDelta.mock.calls[0][0].value).toEqual(toValueReturn)
+                })
+            })
         })
     })
     // tslint:disable-next-line:max-file-line-count

--- a/packages/core/src/forms.spec.ts
+++ b/packages/core/src/forms.spec.ts
@@ -409,7 +409,7 @@ describe("inputstate", () => {
                         toValue: jest.fn().mockReturnValue(toValueReturn)
                     }
                 }
-                it("should should transforn valu with given function", () => {
+                it("should should transform value with given function", () => {
                     validate(inputWithToValue, value)
                     expect(inputWithToValue.schema.toValue).toBeCalledWith(value)
                     expect(inputWithToValue.setDelta.mock.calls[0][0].value).toEqual(toValueReturn)

--- a/packages/core/src/forms.ts
+++ b/packages/core/src/forms.ts
@@ -156,8 +156,8 @@ const getNumberValue = (v: any): any => {
     return isNaN(numberValue) ? v : numberValue
 }
 
-const validate = <T>({ state, schema: { toValue, type, validators }, setDelta }: SimpleInputProps, v: any) => {
-    const value = toValue ? toValue(`${v}`) : type === "number" ? getNumberValue(v) : v
+export const validate = <T>({ state, schema: { toValue, type, validators }, setDelta }: SimpleInputProps, v: any) => {
+    const value = toValue ? toValue(v) : type === "number" ? getNumberValue(v) : v
     const validationResult = validators ? runValidatorsRaw<T, string>(validators, value) : mkOk(value)
     setDelta({ ...state, validationResult, value })
     return validationResult


### PR DESCRIPTION
Removing string cast from validate function before passing value to `toValue` function