### PR TITLE
Remove any from runValidatorsRaw & fix import from utils

### DIFF
--- a/packages/core/src/components/StyledFormView.tsx
+++ b/packages/core/src/components/StyledFormView.tsx
@@ -8,10 +8,9 @@ import {
     FormItemView,
     StyledInputsRenderMap
 } from ".."
-import { pickObject } from "../../../utils"
+import { pickObject, omitObject } from "../../../utils"
 import { InputViewProps } from "./FormView"
 import { styledInputsRenderMap } from "./PlainHtmlRenderMap"
-import { omitObject } from "@react-formless/utils/map"
 
 const isKeyOf = <T extends any>(v: any, keys: string[] = []): v is keyof T =>
     typeof v === "string" && (keys.includes(v) || keys.length === 0)

--- a/packages/core/src/forms.ts
+++ b/packages/core/src/forms.ts
@@ -49,7 +49,7 @@ function validateInput<T>(
     return {
         ...s,
         visited: true,
-        validationResult: schema.validators ? runValidatorsRaw(schema.validators as any, s.value) : mkOk(s.value)
+        validationResult: schema.validators ? runValidatorsRaw(schema.validators, s.value) : mkOk(s.value)
     } as any
 }
 
@@ -68,7 +68,7 @@ function inputStateToInputResult<T>(
     const s: InputState<T> = state as any
     if ((s.visited || s.active) && s.validationResult) return s.validationResult
     const value = schema.toValue ? schema.toValue((state as any).value) : (state as any).value
-    return schema.validators ? runValidatorsRaw(schema.validators as any, value) : mkOk(value)
+    return schema.validators ? runValidatorsRaw(schema.validators, value) : mkOk(value)
 }
 
 export const toResult = <T>(schema: FormSchema<T>, state: FormState<T>): Result<T, T> => {

--- a/packages/utils/validators.ts
+++ b/packages/utils/validators.ts
@@ -1,5 +1,5 @@
 import { iterateMap, keys, copyDefinedFields, SMap } from "./map"
-import { mkNothing, mkJust, SCasted, ValueState, State, F1, Maybe } from "./types"
+import { mkNothing, mkJust, SCasted, ValueState, State, F1, Maybe, ArrayItem } from "./types"
 
 export type Errors<T> = SCasted<T, string>
 export type ErrArray<T> = Array<Err<ExtErrors<T>>>
@@ -104,12 +104,12 @@ export const validateHexColor = (v: any, msg?: string): Result<boolean, string> 
     /^(#[0-9a-f]{3}|#[0-9a-f]{6})$/i.test(v) ? mkOk(v) : mkErr(msg || errors.notHexColor, v)
 
 export const runValidatorsRaw = <T = any, T2 = ExtErrors<T>>(
-    validators: Validators<T, T2>,
+    validators: Validators<ArrayItem<T> | T, T2>,
     value: any
-): Result<T, T2> =>
+): Result<ArrayItem<T> | T, T2> =>
     (validators || []).reduce(
         (acc, validator) => (acc.type === "Err" ? acc : validator(acc.value)),
-        mkOk(value) as Result<T, T2>
+        mkOk(value) as Result<ArrayItem<T> | T, T2>
     )
 
 export const runValidators = <T = any>(validators: Validators<T>, value: any, cb: (err: string) => void) => {


### PR DESCRIPTION
The problem was with `InputOptionSchema` in [index.tsx:66](https://github.com/gmoskal/react-formless/blob/3e28a4aeac246b086fd446855bfe15501a7820c4/packages/core/src/index.tsx#L66)
`export type SimpleInputSchema<T> = InputBoxSchema<T> | InputOptionSchema<ArrayItem<T>>`
it has `ArrayItem<T>` there which cannot be assigned to T (ambiguous).
This fix the issue with validators, but it would be good to check it with the codebase before merging.